### PR TITLE
Remove setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,5 +111,5 @@ paths = ["homewizard_energy"]
 verbose = true
 
 [build-system]
-requires = ["setuptools", "poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I think setuptools is not needed when poetry-core is used for the build.