### PR TITLE
Fill `total_power_*_kwh` when only `total_power_*_t1_kwh` is set

### DIFF
--- a/homewizard_energy/models.py
+++ b/homewizard_energy/models.py
@@ -166,12 +166,16 @@ class Data:
             meter_model=data.get("meter_model"),
             unique_meter_id=Data.convert_hex_string_to_readable(data.get("unique_id")),
             active_tariff=data.get("active_tariff"),
-            total_energy_import_kwh=data.get("total_power_import_kwh"),
+            total_energy_import_kwh=data.get(
+                "total_power_import_kwh", data.get("total_power_import_t1_kwh")
+            ),
             total_energy_import_t1_kwh=data.get("total_power_import_t1_kwh"),
             total_energy_import_t2_kwh=data.get("total_power_import_t2_kwh"),
             total_energy_import_t3_kwh=data.get("total_power_import_t3_kwh"),
             total_energy_import_t4_kwh=data.get("total_power_import_t4_kwh"),
-            total_energy_export_kwh=data.get("total_power_export_kwh"),
+            total_energy_export_kwh=data.get(
+                "total_power_export_kwh", data.get("total_power_export_t1_kwh")
+            ),
             total_energy_export_t1_kwh=data.get("total_power_export_t1_kwh"),
             total_energy_export_t2_kwh=data.get("total_power_export_t2_kwh"),
             total_energy_export_t3_kwh=data.get("total_power_export_t3_kwh"),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -261,8 +261,10 @@ def test_data_energysocket():
     assert data.meter_model is None
     assert data.wifi_ssid == "My Wi-Fi"
     assert data.wifi_strength == 100
+    assert data.total_energy_import_kwh == 10830.511
     assert data.total_energy_import_t1_kwh == 10830.511
     assert data.total_energy_import_t2_kwh is None
+    assert data.total_energy_export_kwh == 2948.827
     assert data.total_energy_export_t1_kwh == 2948.827
     assert data.total_energy_export_t2_kwh is None
     assert data.active_power_w == 123


### PR DESCRIPTION
HWE-SKT does not expose `total_power_import_kwh`, only `total_power_import_t1_kwh`. This PR fixes that for the implementation. 

In a future firmware update we will also add `total_power_import_kwh` to the API.