### PR TITLE
Remove upper constraint for awesomeversion

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2551,4 +2551,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "f4fc8957b4b0ca8ae5564f8f8309c0bc4a3d3a9b645ec27c60809c4bde96f5aa"
+content-hash = "a569bbf346f73a901c53bcb482c39eefc37e5fe3e61f827dc674fa516c613402"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ multidict = "^6.0.5" ## To fix aiohttp dependency at python 3.12
 backoff = "^2.2.1"
 orjson = "^3.10"
 mashumaro = "^3.15"
-awesomeversion = "^24.6.0"
+awesomeversion = ">=24.6.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^3.0.0"


### PR DESCRIPTION
`awesomeversion` uses `CalVer`. The constraint is currently blocking the update to `25.5.0` in Home Assistant.
A new release and bump in Home Assistant would be great.

Ref https://github.com/home-assistant/core/pull/146032